### PR TITLE
Instead of returning nil, return string for unknown types

### DIFF
--- a/Sources/PostgreSQL/Node+Oid.swift
+++ b/Sources/PostgreSQL/Node+Oid.swift
@@ -21,7 +21,8 @@ public enum OID: Oid {
 extension Node {
 	init(oid: Oid, value: String) {
 		guard let type = OID(rawValue: oid) else {
-			self = .null
+            // Always fallback to string, allowing to use with custom types as strings
+			self = .string(value)
 			return
 		}
 
@@ -35,7 +36,8 @@ extension Node {
 		case .bool:
 			self = .bool((value == "t") ? true : false)
 		case .unknown:
-			self = .null
+            // Always fallback to string, allowing to use with custom types as strings
+			self = .string(value)
 		}
 	}
 }

--- a/Sources/PostgreSQL/Node+Oid.swift
+++ b/Sources/PostgreSQL/Node+Oid.swift
@@ -36,8 +36,7 @@ extension Node {
 		case .bool:
 			self = .bool((value == "t") ? true : false)
 		case .unknown:
-			// Always fallback to string, allowing to use with custom types as strings
-			self = .string(value)
+			self = .null
 		}
 	}
 }

--- a/Sources/PostgreSQL/Node+Oid.swift
+++ b/Sources/PostgreSQL/Node+Oid.swift
@@ -21,7 +21,7 @@ public enum OID: Oid {
 extension Node {
 	init(oid: Oid, value: String) {
 		guard let type = OID(rawValue: oid) else {
-            // Always fallback to string, allowing to use with custom types as strings
+			// Always fallback to string, allowing to use with custom types as strings
 			self = .string(value)
 			return
 		}
@@ -36,7 +36,7 @@ extension Node {
 		case .bool:
 			self = .bool((value == "t") ? true : false)
 		case .unknown:
-            // Always fallback to string, allowing to use with custom types as strings
+			// Always fallback to string, allowing to use with custom types as strings
 			self = .string(value)
 		}
 	}

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -6,6 +6,7 @@ class PostgreSQLTests: XCTestCase {
         ("testSelectVersion", testSelectVersion),
         ("testTables", testTables),
         ("testParameterization", testParameterization),
+        ("testCustomType", testCustomType),
     ]
 
     var postgreSQL: PostgreSQL.Database!
@@ -118,5 +119,19 @@ class PostgreSQLTests: XCTestCase {
         } catch {
             XCTFail("Testing parameterization failed: \(error)")
         }
+    }
+    
+    func testCustomType() throws {
+        let uuidString = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
+        let dateString = "2016-10-24 23:04:19.223+00"
+        
+        try postgreSQL.execute("DROP TABLE IF EXISTS foo")
+        try postgreSQL.execute("CREATE TABLE foo (uuid UUID, date TIMESTAMP WITH TIME ZONE)")
+        try postgreSQL.execute("INSERT INTO foo VALUES ($1, $2)", [.string(uuidString), .string(dateString)])
+        
+        let result = try postgreSQL.execute("SELECT * FROM foo").first
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!["uuid"]?.string, uuidString)
+        XCTAssertEqual(result!["date"]?.string, dateString)
     }
 }


### PR DESCRIPTION
I am not really sure if this is the way to go, but this pull request changes the way unknown values are returned. Instead of returning `.null`, now the string is returned directly in a `Node`. This allows to work with custom PostgreSQL types as strings.
