### PR TITLE
cleanup

### DIFF
--- a/Sources/PostgreSQL/Configuration.swift
+++ b/Sources/PostgreSQL/Configuration.swift
@@ -1,0 +1,4 @@
+public struct Configuration {
+    // Indicates whether date and time values are stored as Int64 or Float64
+    public var hasIntegerDatetimes: Bool
+}

--- a/Sources/PostgreSQL/Connection.swift
+++ b/Sources/PostgreSQL/Connection.swift
@@ -6,7 +6,7 @@
 
 public final class Connection {
     public typealias ConnectionPointer = OpaquePointer
-
+    public var configuration: Configuration?
     private(set) var connection: ConnectionPointer!
 
     public var connected: Bool {
@@ -15,11 +15,75 @@ public final class Connection {
         }
         return false
     }
-
-    public init(host: String = "localhost", port: String = "5432", dbname: String, user: String, password: String) throws {
-        self.connection = PQconnectdb("host='\(host)' port='\(port)' dbname='\(dbname)' user='\(user)' password='\(password)' client_encoding='UTF8'")
+    
+    public init(conninfo: String) throws {
+        self.connection = PQconnectdb(conninfo)
         if !self.connected {
             throw DatabaseError.cannotEstablishConnection(error)
+        }
+    }
+
+    public convenience init(
+        host: String = "localhost",
+        port: Int = 5432,
+        dbname: String,
+        user: String,
+        password: String
+    ) throws {
+        try self.init(conninfo: "host='\(host)' port='\(port)' dbname='\(dbname)' user='\(user)' password='\(password)' client_encoding='UTF8'")
+    }
+    
+    @discardableResult
+    public func execute(_ query: String, _ values: [Node]? = []) throws -> [[String: Node]] {
+        guard !query.isEmpty else {
+            throw DatabaseError.noQuery
+        }
+        
+        let values = values ?? []
+        
+        var types: [Oid] = []
+        types.reserveCapacity(values.count)
+        
+        var paramValues: [[Int8]?] = []
+        paramValues.reserveCapacity(values.count)
+        
+        var lengths: [Int32] = []
+        lengths.reserveCapacity(values.count)
+        
+        var formats: [Int32] = []
+        formats.reserveCapacity(values.count)
+        
+        for value in values {
+            let (bytes, oid, format) = value.postgresBindingData
+            paramValues.append(bytes)
+            types.append(oid?.rawValue ?? 0)
+            lengths.append(Int32(bytes?.count ?? 0))
+            formats.append(format.rawValue)
+        }
+        
+        let res: Result.Pointer = PQexecParams(
+            connection, query,
+            Int32(values.count),
+            types, paramValues.map {
+                UnsafePointer<Int8>($0)
+            },
+            lengths,
+            formats,
+            DataFormat.binary.rawValue
+        )
+        
+        defer {
+            PQclear(res)
+        }
+        
+        switch Database.Status(result: res) {
+        case .nonFatalError, .fatalError, .unknown:
+            throw DatabaseError.invalidSQL(message: String(cString: PQresultErrorMessage(res)))
+        case .tuplesOk:
+            let configuration = try getConfiguration()
+            return Result(configuration: configuration, pointer: res).parsed
+        default:
+            return []
         }
     }
 
@@ -48,5 +112,27 @@ public final class Connection {
 
     deinit {
         try? close()
+    }
+    
+    // MARK: - Load Configuration
+    
+    private func getConfiguration() throws -> Configuration {
+        if let configuration = self.configuration {
+            return configuration
+        }
+        
+        let hasIntegerDatetimes = getBooleanParameterStatus(key: "integer_datetimes", default: true)
+        
+        let configuration = Configuration(hasIntegerDatetimes: hasIntegerDatetimes)
+        self.configuration = configuration
+        
+        return configuration
+    }
+    
+    private func getBooleanParameterStatus(key: String, `default` defaultValue: Bool = false) -> Bool {
+        guard let value = PQparameterStatus(connection, "integer_datetimes") else {
+            return defaultValue
+        }
+        return String(cString: value) == "on"
     }
 }

--- a/Sources/PostgreSQL/Connection.swift
+++ b/Sources/PostgreSQL/Connection.swift
@@ -22,7 +22,17 @@ public final class Connection {
             throw DatabaseError.cannotEstablishConnection(error)
         }
     }
-
+    
+    public convenience init(params: [String: String]) throws {
+        var conninfo = ""
+        
+        params.forEach { (key, value) in
+            conninfo += "\(key)='\(value)'"
+        }
+        
+        try self.init(conninfo: conninfo)
+    }
+    
     public convenience init(
         host: String = "localhost",
         port: Int = 5432,

--- a/Sources/PostgreSQL/ConnectionInfo.swift
+++ b/Sources/PostgreSQL/ConnectionInfo.swift
@@ -1,0 +1,29 @@
+#if os(Linux)
+    import CPostgreSQLLinux
+#else
+    import CPostgreSQLMac
+#endif
+
+public enum ConnInfo {
+    case raw(String)
+    case params([String: String])
+    case basic(host: String, port: Int, database: String, user: String, password: String)
+}
+
+public protocol ConnInfoInitializable {
+    init(conninfo: ConnInfo) throws
+}
+
+extension ConnInfoInitializable {
+    public init(params: [String: String]) throws {
+        try self.init(conninfo: .params(params))
+    }
+    
+    public init(host: String, port: Int, database: String, user: String, password: String) throws {
+        try self.init(conninfo: .basic(host: host, port: port, database: database, user: user, password: password))
+    }
+    
+    public init(conninfo: String) throws {
+        try self.init(conninfo: .raw(conninfo))
+    }
+}

--- a/Sources/PostgreSQL/Database.swift
+++ b/Sources/PostgreSQL/Database.swift
@@ -19,27 +19,23 @@ enum DataFormat : Int32 {
 }
 
 public class Database {
-    
     // MARK: - Properties
     
     private let host: String
-    private let port: String
+    private let port: Int
     private let dbname: String
     private let user: String
     private let password: String
     
-    // MARK: - Configuration
-    
-    private var configuration: Configuration?
-    
-    struct Configuration {
-        // Indicates whether date and time values are stored as Int64 or Float64
-        var hasIntegerDatetimes: Bool
-    }
-    
     // MARK: - Init
 
-    public init(host: String = "localhost", port: String = "5432", dbname: String, user: String, password: String) {
+    public init(
+        host: String = "localhost",
+        port: Int = 5432,
+        dbname: String,
+        user: String,
+        password: String
+    ) {
         self.host = host
         self.port = port
         self.dbname = dbname
@@ -57,70 +53,10 @@ public class Database {
         
         let connection = try connection ?? makeConnection()
 
-        let values = values ?? []
-        
-        var types: [Oid] = []
-        types.reserveCapacity(values.count)
-        
-        var paramValues: [[Int8]?] = []
-        paramValues.reserveCapacity(values.count)
-        
-        var lengths: [Int32] = []
-        lengths.reserveCapacity(values.count)
-        
-        var formats: [Int32] = []
-        formats.reserveCapacity(values.count)
-        
-        for value in values {
-            let (bytes, oid, format) = value.postgresBindingData
-            paramValues.append(bytes)
-            types.append(oid?.rawValue ?? 0)
-            lengths.append(Int32(bytes?.count ?? 0))
-            formats.append(format.rawValue)
-        }
-        
-        let res: Result.ResultPointer = PQexecParams(connection.connection, query, Int32(values.count), types, paramValues.map { UnsafePointer<Int8>($0) }, lengths, formats, DataFormat.binary.rawValue)
-
-        defer {
-            PQclear(res)
-        }
-
-        switch Status(result: res) {
-        case .nonFatalError, .fatalError, .unknown:
-            throw DatabaseError.invalidSQL(message: String(cString: PQresultErrorMessage(res)))
-            
-        case .tuplesOk:
-            let configuration = try getConfiguration(connection: connection)
-            return Result(configuration: configuration, resultPointer: res).dictionary
-            
-        default:
-            return []
-        }
+        return try connection.execute(query, values)
     }
 
     public func makeConnection() throws -> Connection {
         return try Connection(host: self.host, port: self.port, dbname: self.dbname, user: self.user, password: self.password)
-    }
-    
-    // MARK: - Load Configuration
-    
-    private func getConfiguration(connection: Connection) throws -> Configuration {
-        if let configuration = self.configuration {
-            return configuration
-        }
-        
-        let hasIntegerDatetimes = getBooleanParameterStatus(connection: connection, key: "integer_datetimes", default: true)
-        
-        let configuration = Configuration(hasIntegerDatetimes: hasIntegerDatetimes)
-        self.configuration = configuration
-        
-        return configuration
-    }
-    
-    private func getBooleanParameterStatus(connection: Connection, key: String, `default` defaultValue: Bool = false) -> Bool {
-        guard let value = PQparameterStatus(connection.connection, "integer_datetimes") else {
-            return defaultValue
-        }
-        return String(cString: value) == "on"
     }
 }

--- a/Sources/PostgreSQL/Database.swift
+++ b/Sources/PostgreSQL/Database.swift
@@ -18,33 +18,16 @@ enum DataFormat : Int32 {
     case binary = 1
 }
 
-public class Database {
+public final class Database: ConnInfoInitializable {
     // MARK: - Properties
-    
-    private let host: String
-    private let port: Int
-    private let dbname: String
-    private let user: String
-    private let password: String
+    public let conninfo: ConnInfo
     
     // MARK: - Init
-
-    public init(
-        host: String = "localhost",
-        port: Int = 5432,
-        dbname: String,
-        user: String,
-        password: String
-    ) {
-        self.host = host
-        self.port = port
-        self.dbname = dbname
-        self.user = user
-        self.password = password
+    public init(conninfo: ConnInfo) throws {
+        self.conninfo = conninfo
     }
     
     // MARK: - Connection
-
     @discardableResult
     public func execute(_ query: String, _ values: [Node]? = [], on connection: Connection? = nil) throws -> [[String: Node]] {
         guard !query.isEmpty else {
@@ -57,6 +40,6 @@ public class Database {
     }
 
     public func makeConnection() throws -> Connection {
-        return try Connection(host: self.host, port: self.port, dbname: self.dbname, user: self.user, password: self.password)
+        return try Connection(conninfo: conninfo)
     }
 }

--- a/Sources/PostgreSQL/Node+Binding.swift
+++ b/Sources/PostgreSQL/Node+Binding.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Core
 
-extension Node {
+protocol Bindable {
+    var postgresBindingData: ([Int8]?, OID?, DataFormat) { get }
+}
+
+extension Node: Bindable {
     var postgresBindingData: ([Int8]?, OID?, DataFormat) {
         switch self {
         case .null:
@@ -69,13 +73,13 @@ extension Node {
     }
 }
 
-extension Bool {
+extension Bool: Bindable {
     var postgresBindingData: ([Int8]?, OID?, DataFormat) {
         return ([self ? 1 : 0], .bool, .binary)
     }
 }
 
-extension Int {
+extension Int: Bindable {
     var postgresBindingData: ([Int8]?, OID?, DataFormat) {
         let count = MemoryLayout.size(ofValue: self)
         
@@ -97,7 +101,7 @@ extension Int {
     }
 }
 
-extension Double {
+extension Double: Bindable {
     var postgresBindingData: ([Int8]?, OID?, DataFormat) {
         let count = MemoryLayout.size(ofValue: self)
         
@@ -117,7 +121,7 @@ extension Double {
     }
 }
 
-extension String {
+extension String: Bindable {
     var postgresBindingData: ([Int8]?, OID?, DataFormat) {
         return (utf8CString.array, .none, .string)
     }

--- a/Sources/PostgreSQL/Node+Oid.swift
+++ b/Sources/PostgreSQL/Node+Oid.swift
@@ -104,7 +104,7 @@ enum OID: Oid {
 }
 
 extension Node {
-    init(configuration: Database.Configuration, oid: Oid, value: UnsafeMutablePointer<Int8>, length: Int) {
+    init(configuration: Configuration, oid: Oid, value: UnsafeMutablePointer<Int8>, length: Int) {
         // Check if we support the type
         guard let type = OID(rawValue: oid) else {
             // Check if we have an array type and try to convert
@@ -121,7 +121,7 @@ extension Node {
         self = Node(configuration: configuration, oid: type, value: value, length: length)
     }
     
-    init(configuration: Database.Configuration, oid: OID, value: UnsafeMutablePointer<Int8>, length: Int) {
+    init(configuration: Configuration, oid: OID, value: UnsafeMutablePointer<Int8>, length: Int) {
         switch oid {
         case .bool:
             self = .bool(value[0] != 0)
@@ -220,7 +220,7 @@ extension Node {
         }
     }
     
-    private init?(configuration: Database.Configuration, arrayValue: UnsafeMutablePointer<Int8>) {
+    private init?(configuration: Configuration, arrayValue: UnsafeMutablePointer<Int8>) {
         let elementOid = Oid(bigEndian: PostgresBinaryUtils.convert(arrayValue.advanced(by: 8)))
         
         // Check if we support the type
@@ -248,7 +248,7 @@ extension Node {
         self = Node.parseArray(configuration: configuration, type: type, dimensionLengths: dimensionLengths, pointer: &pointer)
     }
     
-    private static func parseArray(configuration: Database.Configuration, type: OID, dimensionLengths: [Int], pointer: inout UnsafeMutablePointer<Int8>) -> Node {
+    private static func parseArray(configuration: Configuration, type: OID, dimensionLengths: [Int], pointer: inout UnsafeMutablePointer<Int8>) -> Node {
         // Get the length of the array
         let arrayLength = dimensionLengths[0]
         

--- a/Sources/PostgreSQL/Status.swift
+++ b/Sources/PostgreSQL/Status.swift
@@ -20,7 +20,7 @@ extension Database {
         case emptyQuery
         case unknown
 
-        init(result: Result.ResultPointer) {
+        init(result: Result.Pointer) {
             switch PQresultStatus(result) {
             case PGRES_COMMAND_OK:
                 self = .commandOk

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -37,7 +37,7 @@ class PostgreSQLTests: XCTestCase {
     func testConnectionFailure() throws {
         let database = PostgreSQL.Database(
             host: "127.0.0.1",
-            port: "5432",
+            port: 5432,
             dbname: "some_long_db_name_that_does_not_exist",
             user: "postgres",
             password: ""

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -35,10 +35,10 @@ class PostgreSQLTests: XCTestCase {
     }
     
     func testConnectionFailure() throws {
-        let database = PostgreSQL.Database(
+        let database = try PostgreSQL.Database(
             host: "127.0.0.1",
             port: 5432,
-            dbname: "some_long_db_name_that_does_not_exist",
+            database: "some_long_db_name_that_does_not_exist",
             user: "postgres",
             password: ""
         )

--- a/Tests/PostgreSQLTests/Utilities.swift
+++ b/Tests/PostgreSQLTests/Utilities.swift
@@ -7,7 +7,7 @@ extension PostgreSQL.Database {
         do {
             let postgreSQL = PostgreSQL.Database(
                 host: "127.0.0.1",
-                port: "5432",
+                port: 5432,
                 dbname: "test",
                 user: "postgres",
                 password: ""

--- a/Tests/PostgreSQLTests/Utilities.swift
+++ b/Tests/PostgreSQLTests/Utilities.swift
@@ -5,10 +5,10 @@ import Foundation
 extension PostgreSQL.Database {
     static func makeTestConnection() -> PostgreSQL.Database {
         do {
-            let postgreSQL = PostgreSQL.Database(
+            let postgreSQL = try PostgreSQL.Database(
                 host: "127.0.0.1",
                 port: 5432,
-                dbname: "test",
+                database: "test",
                 user: "postgres",
                 password: ""
             )


### PR DESCRIPTION
- moves `execute` to the connection like MySQL
- adds `Bindable` protocol
- simplifies some naming
- publicizes `Configuration` struct
- adds `params:` init
- New `ConnInfo` enum and protocol for consistent init methods
Fixes #15 