### PR TITLE
Add support for LISTEN and NOTIFY

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ public enum Value {
 }
 ```
 
+### Listen and Notify
+
+```swift
+try postgreSQL.listen(to: "test_channel") { notification in
+    print(notification.channel)
+    print(notification.payload)
+}
+
+// Allow set up time for LISTEN
+sleep(1)
+
+try postgreSQL.notify(channel: "test_channel", payload: "test_payload")
+
+```
+
 ### Connection
 
 Each call to `execute()` creates a new connection to the PostgreSQL database. This ensures thread safety since a single connection cannot be used on more than one thread.

--- a/Sources/PostgreSQL/Database.swift
+++ b/Sources/PostgreSQL/Database.swift
@@ -1,4 +1,5 @@
 import CPostgreSQL
+import Core
 
 public enum DatabaseError: Error {
     case cannotEstablishConnection(String)
@@ -34,7 +35,47 @@ public final class Database: ConnInfoInitializable {
 
         return try connection.execute(query, values)
     }
+	
+	public func listen(to channel: String, callback: @escaping (Notification) -> Void) {
+		background {
+			do {
+				let connection = try self.makeConnection()
+				
+				try self.execute("LISTEN \(channel)", on: connection)
+				
+				while true {
+					if connection.connected != true {
+						throw DatabaseError.cannotEstablishConnection(connection.error)
+					}
+					
+					PQconsumeInput(connection.connection)
+					
+					while let pgNotify = PQnotifies(connection.connection) {
+						let notification = Notification(relname: pgNotify.pointee.relname, extra: pgNotify.pointee.extra, be_pid: pgNotify.pointee.be_pid)
+						
+						callback(notification)
+						
+						PQfreemem(pgNotify)
+					}
+				}
+			}
+			catch {
+				fatalError("\(error)")
+			}
+		}
+	}
 
+	public func notify(channel: String, payload: String?, on connection: Connection? = nil) throws {
+		let connection = try connection ?? makeConnection()
+		
+		if let payload = payload {
+			try execute("NOTIFY \(channel), '\(payload)'", on: connection)
+		}
+		else {
+			try execute("NOTIFY \(channel)", on: connection)
+		}
+	}
+	
     public func makeConnection() throws -> Connection {
         return try Connection(conninfo: conninfo)
     }

--- a/Sources/PostgreSQL/Notification.swift
+++ b/Sources/PostgreSQL/Notification.swift
@@ -1,0 +1,19 @@
+public struct Notification {
+	let channel: String
+	let payload: String?
+	let pid: Int
+}
+
+extension Notification {
+	init(relname: UnsafeMutablePointer<Int8>, extra: UnsafeMutablePointer<Int8>, be_pid: Int32) {
+		self.channel = String(cString: relname)
+		self.pid = Int(be_pid)
+		
+		if (extra.pointee != 0) {
+			self.payload = String(cString: extra)
+		}
+		else {
+			self.payload = nil
+		}
+	}
+}

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -26,6 +26,8 @@ class PostgreSQLTests: XCTestCase {
         ("testBitStrings", testBitStrings),
         ("testVarBitStrings", testVarBitStrings),
         ("testUnsupportedObject", testUnsupportedObject),
+        ("testNotification", testNotification),
+        ("testNotificationWithPayload", testNotificationWithPayload),
     ]
 
     var postgreSQL: PostgreSQL.Database!
@@ -660,4 +662,38 @@ class PostgreSQLTests: XCTestCase {
             XCTAssertNotNil(value)
         }
     }
+	
+	func testNotification() throws {
+		let testExpectation = expectation(description: "Receive notification")
+		
+		postgreSQL.listen(to: "test_channel1") { notification in
+			XCTAssertEqual(notification.channel, "test_channel1")
+			XCTAssertNil(notification.payload)
+			
+			testExpectation.fulfill()
+		}
+		
+		sleep(1)
+		
+		try postgreSQL.notify(channel: "test_channel1", payload: nil)
+		
+		waitForExpectations(timeout: 5)
+	}
+	
+	func testNotificationWithPayload() throws {
+		let testExpectation = expectation(description: "Receive notification with payload")
+		
+		postgreSQL.listen(to: "test_channel2") { notification in
+			XCTAssertEqual(notification.channel, "test_channel2")
+			XCTAssertEqual(notification.payload, "test_payload")
+			
+			testExpectation.fulfill()
+		}
+		
+		sleep(1)
+		
+		try postgreSQL.notify(channel: "test_channel2", payload: "test_payload")
+		
+		waitForExpectations(timeout: 5)
+	}
 }


### PR DESCRIPTION
I'm not all that comfortable with `libpq` so give this extra scrutiny. 🙊 

I used [this example](https://www.postgresql.org/docs/9.6/static/libpq-example.html#LIBPQ-EXAMPLE-2) heavily to help me determine how to receive notifications using `libpq`. I also purposefully broke convention and used a closure in `listen` instead of creating a `onNotification` property off `Database` since a database could be listening to multiple channels simultaneously.

Couple of things that I wanted to point out for feedback:
- What to do with errors caught in `listen` since the closure in `try background` can't throw? Using `fatalError` right now but not sure if that's the correct approach.
- The name of the `Notification` struct. It's not really meant to be used outside the `listen` closure so it's maybe okay to keep named as is even though it collides with Foundation's own `Notification`.