### PR TITLE
Update CI configuration for the new vapor scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ script:
   - swift build -Xswiftc -DNO_ANIMATION
   - swift build --configuration release -Xswiftc -DNO_ANIMATION
   - swift test
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ matrix:
       osx_image: xcode8.3
 
 before_install:
-  - brew tap vapor/tap;
-  - brew update;
-  - brew install vapor;
+  - gem install xcpretty
+  - brew tap vapor/tap
+  - brew update
+  - brew install vapor
 
 install:
   - rm -rf /usr/local/var/postgres
@@ -20,7 +21,7 @@ script:
   # run unit tests
   - swift build --configuration release
   - swift package generate-xcodeproj
-  - xcodebuild -scheme PostgreSQL -enableCodeCoverage YES test  # instead of swift test
+  - xcodebuild -scheme PostgreSQL -enableCodeCoverage YES test | xcpretty  # instead of swift test
 
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ install:
 
 script:
   # run unit tests
-  - swift build -Xswiftc -DNO_ANIMATION
-  - swift build --configuration release -Xswiftc -DNO_ANIMATION
-  - swift test
+  - swift build --configuration release
+  - swift package generate-xcodeproj
+  - xcodebuild -scheme PostgreSQL -enableCodeCoverage YES test  # instead of swift test
+
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
-language: ruby
+language: generic
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      sudo: required
-      addons:
-        postgresql: 9.5
     - os: osx
       osx_image: xcode8.3
+
+before_install:
+  - brew tap vapor/tap;
+  - brew update;
+  - brew install vapor;
+
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm -rf /usr/local/var/postgres && initdb /usr/local/var/postgres -E utf8; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pg_ctl -D /usr/local/var/postgres start && sleep 3 || true; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo -u travis createuser -s -p 5432 postgres; fi
+  - rm -rf /usr/local/var/postgres
+  - initdb /usr/local/var/postgres -E utf8
+  - pg_ctl -D /usr/local/var/postgres start && sleep 3 || true
+  - sudo -u travis createuser -s -p 5432 postgres
   - psql -U postgres -c 'create database test;'
+
 script:
-  - eval "$(curl -sL https://swift.vapor.sh/ci-3.1)"
-  - eval "$(curl -sL https://swift.vapor.sh/codecov)"
+  # run unit tests
+  - swift build -Xswiftc -DNO_ANIMATION
+  - swift build --configuration release -Xswiftc -DNO_ANIMATION
+  - swift test

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,14 @@
 dependencies:
+  override:
+    - eval "$(curl -sL https://apt.vapor.sh)"
+    - sudo apt-get install vapor
+    - sudo chmod -R a+rx /usr/
+
   pre:
-    - sudo -u postgres createuser user_testing
-    - createdb test
+    - sudo -u postgres createdb test
 
 test:
   override:
-    - eval "$(curl -sL https://swift.vapor.sh/ci-3.1)"
+    - swift build
+    - swift build -c release
+    - swift test


### PR DESCRIPTION
The swift.vapor.sh domain disappeared, so tests on both Circle and Travis simply pass without doing anything.

The sudo-enabled Linux image on Travis is a mess, so from now on:
- Circle will test the package on Linux – with the new scripts;
- Travis will only test on macOS – as standalone as possible.