### PR TITLE
.date node type

### DIFF
--- a/Sources/PostgreSQL/Node+Binding.swift
+++ b/Sources/PostgreSQL/Node+Binding.swift
@@ -39,9 +39,10 @@ extension Node: Bindable {
             print("Unsupported Node type for PostgreSQL binding, everything except for .object is supported.")
             return (nil, nil, .string)
 
-        default:
-            return (nil, nil, .string)
-        }
+		case .date(let date):
+			return date.postgresBindingData
+		}
+
     }
 }
 
@@ -75,9 +76,12 @@ extension StructuredData {
             print("Unsupported Node array type for PostgreSQL binding, everything except for .object is supported.")
             return "NULL"
 
-        default:
-            return ""
-        }
+		case .date(let date):
+			let formatter = DateFormatter()
+			formatter.timeZone = TimeZone(secondsFromGMT: 0)
+			formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ G"
+			return formatter.string(from: date)
+		}
     }
 }
 
@@ -133,4 +137,14 @@ extension String: Bindable {
     var postgresBindingData: ([Int8]?, OID?, DataFormat) {
         return (utf8CString.array, .none, .string)
     }
+}
+
+extension Date: Bindable {
+	var postgresBindingData: ([Int8]?, OID?, DataFormat) {
+		let formatter = DateFormatter()
+		formatter.timeZone = TimeZone(secondsFromGMT: 0)
+		formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ G"
+		let string = formatter.string(from: self)
+		return (string.utf8CString.array, .none, .string)
+	}
 }

--- a/Sources/PostgreSQL/Node+Binding.swift
+++ b/Sources/PostgreSQL/Node+Binding.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Core
 
+let dateFormatter = DateFormatter()
+
+
 protocol Bindable {
     var postgresBindingData: ([Int8]?, OID?, DataFormat) { get }
 }
@@ -77,10 +80,9 @@ extension StructuredData {
             return "NULL"
 
 		case .date(let date):
-			let formatter = DateFormatter()
-			formatter.timeZone = TimeZone(secondsFromGMT: 0)
-			formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ G"
-			return formatter.string(from: date)
+			dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+			dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ G"
+			return dateFormatter.string(from: date)
 		}
     }
 }
@@ -141,10 +143,9 @@ extension String: Bindable {
 
 extension Date: Bindable {
 	var postgresBindingData: ([Int8]?, OID?, DataFormat) {
-		let formatter = DateFormatter()
-		formatter.timeZone = TimeZone(secondsFromGMT: 0)
-		formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ G"
-		let string = formatter.string(from: self)
+		dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+		dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSSZ G"
+		let string = dateFormatter.string(from: self)
 		return (string.utf8CString.array, .none, .string)
 	}
 }

--- a/Sources/PostgreSQL/Node+Oid.swift
+++ b/Sources/PostgreSQL/Node+Oid.swift
@@ -168,12 +168,17 @@ extension Node {
             let uuid = PostgresBinaryUtils.parseUUID(value: value)
             self = .string(uuid)
             
-        case .timestamp, .timestamptz, .date, .time, .timetz:
+        case .timestamp, .timestamptz, .time, .timetz:
             let date = PostgresBinaryUtils.parseTimetamp(value: value, isInteger: configuration.hasIntegerDatetimes)
             let formatter = PostgresBinaryUtils.Formatters.dateFormatter(for: oid)
             let timestamp = formatter.string(from: date)
-            self = .string(timestamp)
-            
+			let formattedDate : Date = formatter.date(from: timestamp)!
+			self = .date(formattedDate)
+			
+		case .date:
+			let date = PostgresBinaryUtils.parseDate(value: value)
+			self = .date(date)
+			
         case .interval:
             let interval = PostgresBinaryUtils.parseInterval(value: value, timeIsInteger: configuration.hasIntegerDatetimes)
             self = .string(interval)

--- a/Sources/PostgreSQL/PostgresBinaryUtils.swift
+++ b/Sources/PostgreSQL/PostgresBinaryUtils.swift
@@ -68,10 +68,10 @@ struct PostgresBinaryUtils {
             return formatter
         }
         
-        private static let timestamp: DateFormatter = formatter(format: "yyyy-MM-dd HH:mm:ss.SSS", forceUTC: true)
-        private static let timestamptz: DateFormatter = formatter(format: "yyyy-MM-dd HH:mm:ss.SSSX", forceUTC: false)
+        private static let timestamp: DateFormatter = formatter(format: "yyyy-MM-dd HH:mm:ss.SSS G", forceUTC: true)
+        private static let timestamptz: DateFormatter = formatter(format: "yyyy-MM-dd HH:mm:ss.SSSZ G", forceUTC: false)
         
-        private static let date: DateFormatter = formatter(format: "yyyy-MM-dd", forceUTC: false)
+        private static let date: DateFormatter = formatter(format: "yyyy-MM-dd G", forceUTC: true)
         
         private static let time: DateFormatter = formatter(format: "HH:mm:ss.SSS", forceUTC: true)
         private static let timetz: DateFormatter = formatter(format: "HH:mm:ss.SSSX", forceUTC: false)
@@ -278,6 +278,11 @@ struct PostgresBinaryUtils {
         }
         return Date(timeInterval: interval, since: TimestampConstants.referenceDate)
     }
+	
+	static func parseDate(value: UnsafeMutablePointer<Int8>) -> Date {
+		let interval = Int(parseInt32(value: value)) * 24 * 60 * 60
+		return Date(timeInterval: TimeInterval(interval), since: TimestampConstants.referenceDate)
+	}
     
     // MARK: - Interval
     

--- a/Sources/PostgreSQL/PostgresBinaryUtils.swift
+++ b/Sources/PostgreSQL/PostgresBinaryUtils.swift
@@ -1,6 +1,10 @@
 import Foundation
 import Core
 
+let hoursInDay = 24;
+let minutesInHour = 60;
+let secondsInMinutes = 60;
+
 extension UInt8 {
     var lowercaseHexPair: String {
         let hexString = String(self, radix: 16, uppercase: false)
@@ -280,7 +284,7 @@ struct PostgresBinaryUtils {
     }
 	
 	static func parseDate(value: UnsafeMutablePointer<Int8>) -> Date {
-		let interval = Int(parseInt32(value: value)) * 24 * 60 * 60
+		let interval = Int(parseInt32(value: value)) * hoursInDay * minutesInHour * secondsInMinutes
 		return Date(timeInterval: TimeInterval(interval), since: TimestampConstants.referenceDate)
 	}
     

--- a/Tests/PostgreSQLTests/ArrayTests.swift
+++ b/Tests/PostgreSQLTests/ArrayTests.swift
@@ -95,8 +95,8 @@ class ArrayTests: XCTestCase {
 	func testDateArray() throws {
 		let date  = "2016-10-24 23:04:19.000".postgreSQLParsedDate
 		let date2 = "2017-10-24 23:04:19.000".postgreSQLParsedDate
-		let dateLowValue = Date.init().timestampLowValue
-		let dateHighValue = Date.init().timestampHighValue
+		let dateLowValue = Date.init().timestampMinimumValue
+		let dateHighValue = Date.init().timestampMaximumValue
 		let rows  = [
 			[date],
 			[date,date2],

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -10,19 +10,19 @@ class PostgreSQLTests: XCTestCase {
         ("testDataType", testDataType),
         ("testDateAsStringTypeWithOutTimeZone", testDateAsStringTypeWithOutTimeZone),
         ("testDateAsStringTypeWithTimeZone", testDateAsStringTypeWithTimeZone),
-        ("testTimeStampNoTimezoneTypeLowValue", testTimeStampNoTimezoneTypeLowValue),
+        ("testTimeStampNoTimezoneTypeMinimumValue", testTimeStampNoTimezoneTypeMinimumValue),
         ("testTimeStampNoTimezoneTypeCurrentDate", testTimeStampNoTimezoneTypeCurrentDate),
-        ("testTimeStampNoTimezoneTypeHighValue", testTimeStampNoTimezoneTypeHighValue),
-        ("testTimeStampTimezoneTypeLowValue", testTimeStampTimezoneTypeLowValue),
-        ("testTimeStampTimezoneTypeHighValue", testTimeStampTimezoneTypeHighValue),
+        ("testTimeStampNoTimezoneTypeMaximumValue", testTimeStampNoTimezoneTypeMaximumValue),
+        ("testTimeStampTimezoneTypeMinimumValue", testTimeStampTimezoneTypeMinimumValue),
+        ("testTimeStampTimezoneTypeMaximumValue", testTimeStampTimezoneTypeMaximumValue),
         ("testTimeStampTimezoneType", testTimeStampTimezoneType),
-        ("testDateTypeLowValue", testDateTypeLowValue),
-        ("testDateTypeHighValue", testDateTypeHighValue),
+        ("testDateTypeMinimumValue", testDateTypeMinimumValue),
+        ("testDateTypeMaximumValue", testDateTypeMaximumValue),
         ("testDateType", testDateType),
-        ("testTimeTypeHighValue", testTimeTypeHighValue),
-        ("testTimeTypeLowValue", testTimeTypeLowValue),
-        ("testTimeWithTimeZoneTypeHighValue", testTimeWithTimeZoneTypeHighValue),
-        ("testTimeWithTimeZoneTypeLowValue", testTimeWithTimeZoneTypeLowValue),
+        ("testTimeTypeMaximumValue", testTimeTypeMaximumValue),
+        ("testTimeTypeMinimumValue", testTimeTypeMinimumValue),
+        ("testTimeWithTimeZoneTypeMaximumValue", testTimeWithTimeZoneTypeMaximumValue),
+        ("testTimeWithTimeZoneTypeMinimumValue", testTimeWithTimeZoneTypeMinimumValue),
         ("testInts", testInts),
         ("testFloats", testFloats),
         ("testNumeric", testNumeric),
@@ -206,7 +206,7 @@ class PostgreSQLTests: XCTestCase {
 	}
 
 
-	func testTimeStampNoTimezoneTypeLowValue() throws {
+	func testTimeStampNoTimezoneTypeMinimumValue() throws {
 		let uuidString = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let date = Date.init().timestampMinimumValue;
 		
@@ -237,7 +237,7 @@ class PostgreSQLTests: XCTestCase {
 		XCTAssertEqual(result!["date"]?.date,expectedDateIsUTC)
 	}
 	
-	func testTimeStampNoTimezoneTypeHighValue() throws {
+	func testTimeStampNoTimezoneTypeMaximumValue() throws {
 		let uuidString = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let date = Date.init().timestampMaximumValue
 		
@@ -251,7 +251,7 @@ class PostgreSQLTests: XCTestCase {
 		XCTAssertEqual(result!["date"]?.date,date)
 	}
 	
-	func testTimeStampTimezoneTypeLowValue() throws {
+	func testTimeStampTimezoneTypeMinimumValue() throws {
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let date : Date = Date.init().timestampMinimumValue
 		
@@ -265,7 +265,7 @@ class PostgreSQLTests: XCTestCase {
 		XCTAssertEqual(result!["date"]?.date,date)
 	}
 	
-	func testTimeStampTimezoneTypeHighValue() throws {
+	func testTimeStampTimezoneTypeMaximumValue() throws {
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let date : Date = Date.init().timestampMaximumValue
 		
@@ -295,7 +295,7 @@ class PostgreSQLTests: XCTestCase {
 		XCTAssertEqual(result!["date"]?.date,expectedDateIsUTC)
 	}
 	
-	func testDateTypeLowValue() throws {
+	func testDateTypeMinimumValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.date)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let dateString  = formatter.string(from: Date.init().dateMinimumValue)
@@ -311,7 +311,7 @@ class PostgreSQLTests: XCTestCase {
 		XCTAssertEqual(result!["date"]?.date,date)
 	}
 	
-	func testDateTypeHighValue() throws {
+	func testDateTypeMaximumValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.date)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let dateString  = formatter.string(from: Date.init().dateMaximumValue)
@@ -344,7 +344,7 @@ class PostgreSQLTests: XCTestCase {
 		XCTAssertEqual(result!["date"]?.date,date)
 	}
 	
-	func testTimeTypeHighValue() throws {
+	func testTimeTypeMaximumValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.time)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let dateString  = "23:59:59.999"
@@ -360,7 +360,7 @@ class PostgreSQLTests: XCTestCase {
 		XCTAssertEqual(result!["date"]?.date,date)
 	}
 	
-	func testTimeTypeLowValue() throws {
+	func testTimeTypeMinimumValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.time)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let dateString  = "00:00:00.000"
@@ -378,7 +378,7 @@ class PostgreSQLTests: XCTestCase {
 		
 	}
 	
-	func testTimeWithTimeZoneTypeHighValue() throws {
+	func testTimeWithTimeZoneTypeMaximumValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.timetz)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let dateString  = "23:59:59.999-1459"
@@ -395,7 +395,7 @@ class PostgreSQLTests: XCTestCase {
 		
 	}
 	
-	func testTimeWithTimeZoneTypeLowValue() throws {
+	func testTimeWithTimeZoneTypeMinimumValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.timetz)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
 		let dateString  = "00:00:00.000+1459"

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -208,7 +208,7 @@ class PostgreSQLTests: XCTestCase {
 
 	func testTimeStampNoTimezoneTypeLowValue() throws {
 		let uuidString = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
-		let date = Date.init().timestampLowValue;
+		let date = Date.init().timestampMinimumValue;
 		
 		try postgreSQL.execute("DROP TABLE IF EXISTS foo")
 		try postgreSQL.execute("CREATE TABLE foo (uuid UUID, date TIMESTAMP WITHOUT TIME ZONE)")
@@ -239,7 +239,7 @@ class PostgreSQLTests: XCTestCase {
 	
 	func testTimeStampNoTimezoneTypeHighValue() throws {
 		let uuidString = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
-		let date = Date.init().timestampHighValue
+		let date = Date.init().timestampMaximumValue
 		
 		try postgreSQL.execute("DROP TABLE IF EXISTS foo")
 		try postgreSQL.execute("CREATE TABLE foo (uuid UUID, date TIMESTAMP WITHOUT TIME ZONE)")
@@ -253,7 +253,7 @@ class PostgreSQLTests: XCTestCase {
 	
 	func testTimeStampTimezoneTypeLowValue() throws {
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
-		let date : Date = Date.init().timestampLowValue
+		let date : Date = Date.init().timestampMinimumValue
 		
 		try postgreSQL.execute("DROP TABLE IF EXISTS foo")
 		try postgreSQL.execute("CREATE TABLE foo (uuid UUID, date TIMESTAMP WITH TIME ZONE)")
@@ -267,7 +267,7 @@ class PostgreSQLTests: XCTestCase {
 	
 	func testTimeStampTimezoneTypeHighValue() throws {
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
-		let date : Date = Date.init().timestampHighValue
+		let date : Date = Date.init().timestampMaximumValue
 		
 		try postgreSQL.execute("DROP TABLE IF EXISTS foo")
 		try postgreSQL.execute("CREATE TABLE foo (uuid UUID, date TIMESTAMP WITH TIME ZONE)")
@@ -298,7 +298,7 @@ class PostgreSQLTests: XCTestCase {
 	func testDateTypeLowValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.date)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
-		let dateString  = formatter.string(from: Date.init().dateLowValue)
+		let dateString  = formatter.string(from: Date.init().dateMinimumValue)
 		let date : Date = formatter.date(from: dateString)!
 		
 		try postgreSQL.execute("DROP TABLE IF EXISTS foo")
@@ -314,7 +314,7 @@ class PostgreSQLTests: XCTestCase {
 	func testDateTypeHighValue() throws {
 		let formatter   = PostgresBinaryUtils.Formatters.dateFormatter(for: OID.date)
 		let uuidString  = "7fe1743a-96a8-417c-b6c2-c8bb20d3017e"
-		let dateString  = formatter.string(from: Date.init().dateHighValue)
+		let dateString  = formatter.string(from: Date.init().dateMaximumValue)
 		let date : Date = formatter.date(from: dateString)!
 		
 		

--- a/Tests/PostgreSQLTests/Utilities.swift
+++ b/Tests/PostgreSQLTests/Utilities.swift
@@ -84,7 +84,7 @@ extension Float64 {
 }
 
 extension Date {
-	var timestampLowValue: Date {
+	var timestampMinimumValue: Date {
 		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
 		var dateComponents = DateComponents()
 		dateComponents.era = 0
@@ -99,7 +99,7 @@ extension Date {
 		return userCalendar.date(from: dateComponents)!
 	}
 	
-	var timestampHighValue: Date {
+	var timestampMaximumValue: Date {
 		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
 		var dateComponents = DateComponents()
 		dateComponents.era = 1
@@ -114,7 +114,7 @@ extension Date {
 		return userCalendar.date(from: dateComponents)!
 	}
 	
-	var dateLowValue: Date {
+	var dateMinimumValue: Date {
 		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
 		var dateComponents = DateComponents()
 		dateComponents.era = 0
@@ -125,7 +125,7 @@ extension Date {
 		return userCalendar.date(from: dateComponents)!
 	}
 	
-	var dateHighValue: Date {
+	var dateMaximumValue: Date {
 		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
 		var dateComponents = DateComponents()
 		dateComponents.era = 1

--- a/Tests/PostgreSQLTests/Utilities.swift
+++ b/Tests/PostgreSQLTests/Utilities.swift
@@ -82,3 +82,58 @@ extension Float64 {
     static let min = Float64(bitPattern: 0x0010000000000000)
     static let max = Float64(bitPattern: 0x7fefffffffffffff)
 }
+
+extension Date {
+	var timestampLowValue: Date {
+		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
+		var dateComponents = DateComponents()
+		dateComponents.era = 0
+		dateComponents.year = 4713
+		dateComponents.month = 1
+		dateComponents.day = 1
+		dateComponents.hour = 0
+		dateComponents.minute = 0
+		dateComponents.second = 0
+		dateComponents.timeZone = TimeZone(abbreviation: "UTC")
+		
+		return userCalendar.date(from: dateComponents)!
+	}
+	
+	var timestampHighValue: Date {
+		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
+		var dateComponents = DateComponents()
+		dateComponents.era = 1
+		dateComponents.year = 144683  //Highest number the formatter would allow; Postgres can go to 294276
+		dateComponents.month = 1
+		dateComponents.day = 1
+		dateComponents.hour = 0
+		dateComponents.minute = 0
+		dateComponents.second = 0
+		dateComponents.timeZone = TimeZone(abbreviation: "UTC")
+		
+		return userCalendar.date(from: dateComponents)!
+	}
+	
+	var dateLowValue: Date {
+		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
+		var dateComponents = DateComponents()
+		dateComponents.era = 0
+		dateComponents.year = 4713
+		dateComponents.month = 1
+		dateComponents.day = 1
+		
+		return userCalendar.date(from: dateComponents)!
+	}
+	
+	var dateHighValue: Date {
+		let userCalendar = Calendar.init(identifier: Calendar.Identifier.gregorian)
+		var dateComponents = DateComponents()
+		dateComponents.era = 1
+		dateComponents.year = 144683  //Highest number the formatter would allow; Postgres can go to 5874897
+		dateComponents.month = 1
+		dateComponents.day = 1
+		
+		return userCalendar.date(from: dateComponents)!
+	}
+	
+}


### PR DESCRIPTION
The code now handles .date node type. The code now handles Postgresql low values in B.C. There are tests for all Date/Time types. The code now parses date type better.