### PR TITLE
Removed unnessesary print

### DIFF
--- a/Sources/PostgreSQL/Bind/Bind+Node.swift
+++ b/Sources/PostgreSQL/Bind/Bind+Node.swift
@@ -26,7 +26,7 @@ extension Bind {
             return Bind.parse(type: supportedArrayType, configuration: configuration, value: value, length: length)
             
         case .unsupported(let oid):
-            print("Unsupported Oid type for PostgreSQL binding (\(oid)).")
+            // Unsupported Oid type for PostgreSQL binding.
             
             // Fallback to simply passing on the bytes
             let bytes = BinaryUtils.parseBytes(value: value, length: length)


### PR DESCRIPTION
The .unsupported case is by no means a problem - simply using postgres enums will cause each and every bind to print out this message. As the function still returns the data (in the form of bytes) it makes more sense that any issue with this will be caught in higher level testing.