### PR TITLE
Added support for Notifications that use DispatchSource

### DIFF
--- a/Sources/PostgreSQL/Bind/Bind+Node.swift
+++ b/Sources/PostgreSQL/Bind/Bind+Node.swift
@@ -25,7 +25,7 @@ extension Bind {
         case .array(let supportedArrayType):
             return Bind.parse(type: supportedArrayType, configuration: configuration, value: value, length: length)
             
-        case .unsupported(let oid):
+        case .unsupported(_):
             // Unsupported Oid type for PostgreSQL binding.
             
             // Fallback to simply passing on the bytes

--- a/Sources/PostgreSQL/Connection.swift
+++ b/Sources/PostgreSQL/Connection.swift
@@ -171,6 +171,37 @@ public final class Connection: ConnInfoInitializable {
         }
     }
     
+    /// Creates a dispatch read source for this connection that will call `callback` on `queue` when a notification is received
+    ///
+    /// - Parameter channel: the channel to register for
+    /// - Parameter queue: the queue to create the DispatchSource on
+    /// - Parameter callback: the callback
+    /// - Parameter note: The notification received from the database
+    /// - Parameter err: Any error while reading the notification. If not nil, the source will have been canceled
+    /// - Returns: the dispatch socket to activate
+    /// - Throws: if fails to get the socket for the connection
+    public func makeListenDispatchSource(toChannel channel: String, queue: DispatchQueue, callback: @escaping (_ note: Notification?, _ err: Error?) -> Void) throws -> DispatchSourceRead {
+        guard let sock = Optional.some(PQsocket(self.cConnection)), sock >= 0
+            else { throw PostgreSQLError(code: .ioError, reason: "failed to get socket for connection") }
+        let src = DispatchSource.makeReadSource(fileDescriptor: sock, queue: queue)
+        src.setEventHandler { [unowned self] in
+            do {
+                try self.validateConnection()
+                PQconsumeInput(self.cConnection)
+                while let pgNotify = PQnotifies(self.cConnection) {
+                    let notification = Notification(pgNotify: pgNotify.pointee)
+                    callback(notification, nil)
+                    PQfreemem(pgNotify)
+                }
+            } catch {
+                callback(nil, error)
+                src.cancel()
+            }
+        }
+        try self.execute("LISTEN \(channel)")
+        return src
+    }
+    
     /// Registers as a listener on a specific notification channel.
     ///
     /// - Parameters:

--- a/Sources/PostgreSQL/Connection.swift
+++ b/Sources/PostgreSQL/Connection.swift
@@ -152,6 +152,15 @@ public final class Connection: ConnInfoInitializable {
         public let channel: String
         public let payload: String?
         
+        /// initializer usable without knowledge of CPostgreSQL
+        /// required to allow unit testing of classes using Notifications
+        public init(pid: Int, channel: String, payload: String?) {
+            self.pid = pid
+            self.channel = channel
+            self.payload = payload
+        }
+        
+        /// internal initializer
         init(pgNotify: PGnotify) {
             channel = String(cString: pgNotify.relname)
             pid = Int(pgNotify.be_pid)

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -779,6 +779,31 @@ class PostgreSQLTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
+	func testDispatchNotification() throws {
+		let conn1 = try postgreSQL.makeConnection()
+		let conn2 = try postgreSQL.makeConnection()
+		
+		let testExpectation = expectation(description: "Receive notification")
+		
+		let queue = DispatchQueue.global()
+		var source: DispatchSourceRead?
+		source = try! conn1.makeListenDispatchSource(toChannel: "test_channel1", queue: queue) { (notification, error) in
+			XCTAssertEqual(notification?.channel, "test_channel1")
+			XCTAssertNil(notification?.payload)
+			XCTAssertNil(error)
+			
+			testExpectation.fulfill()
+			source?.cancel()
+		}
+		source?.resume()
+		
+		sleep(1)
+		
+		try conn2.notify(channel: "test_channel1", payload: nil)
+		
+		waitForExpectations(timeout: 5)
+	}
+
     func testNotificationWithPayload() throws {
         let conn1 = try postgreSQL.makeConnection()
         let conn2 = try postgreSQL.makeConnection()
@@ -800,6 +825,32 @@ class PostgreSQLTests: XCTestCase {
 
         waitForExpectations(timeout: 5)
     }
+
+	func testDispatchNotificationWithPayload() throws {
+		let conn1 = try postgreSQL.makeConnection()
+		let conn2 = try postgreSQL.makeConnection()
+		
+		let testExpectation = expectation(description: "Receive notification with payload")
+		
+		let queue = DispatchQueue.global()
+		var source: DispatchSourceRead?
+		source = try! conn1.makeListenDispatchSource(toChannel: "test_channel2", queue: queue) { (notification, error) in
+			XCTAssertEqual(notification?.channel, "test_channel1")
+			XCTAssertEqual(notification?.payload, "test_payload")
+			XCTAssertNil(notification?.payload)
+			XCTAssertNil(error)
+			
+			testExpectation.fulfill()
+			source?.cancel()
+		}
+		source?.resume()
+		
+		sleep(1)
+		
+		try conn2.notify(channel: "test_channel2", payload: "test_payload")
+		
+		waitForExpectations(timeout: 5)
+	}
 
     func testQueryToNode() throws {
         let conn = try postgreSQL.makeConnection()

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -30,6 +30,8 @@ class PostgreSQLTests: XCTestCase {
         ("testUnsupportedObject", testUnsupportedObject),
         ("testNotification", testNotification),
         ("testNotificationWithPayload", testNotificationWithPayload),
+        ("testDispatchNotification", testDispatchNotification),
+        ("testDispatchNotificationWithPayload", testDispatchNotificationWithPayload),
         ("testQueryToNode", testQueryToNode)
     ]
 

--- a/Tests/PostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/PostgreSQLTests/PostgreSQLTests.swift
@@ -837,9 +837,9 @@ class PostgreSQLTests: XCTestCase {
 		let queue = DispatchQueue.global()
 		var source: DispatchSourceRead?
 		source = try! conn1.makeListenDispatchSource(toChannel: "test_channel2", queue: queue) { (notification, error) in
-			XCTAssertEqual(notification?.channel, "test_channel1")
+			XCTAssertEqual(notification?.channel, "test_channel2")
 			XCTAssertEqual(notification?.payload, "test_payload")
-			XCTAssertNil(notification?.payload)
+			XCTAssertNotNil(notification?.payload)
 			XCTAssertNil(error)
 			
 			testExpectation.fulfill()


### PR DESCRIPTION
Using a DispatchSource is less wasteful of CPU power as per [PostgreSQL documentation](https://www.postgresql.org/docs/9.6/static/libpq-notify.html).

 A parametrized init for Connection.Notification is needed so an application using Notifications does not need to import CPostgreSQL. 

Fixed a compiler warning about an unused variable.
