### PR TITLE
Update Travis-CI build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PostgreSQL for Swift
 
 [![Swift](http://img.shields.io/badge/swift-3.1-brightgreen.svg)](https://swift.org)
-[![Build Status](https://travis-ci.org/vapor/postgresql.svg?branch=master)](https://travis-ci.org/vapor/postgresql)
+[![Build Status](https://travis-ci.org/vapor-community/postgresql.svg?branch=execute-w-values-bug)](https://travis-ci.org/vapor-community/postgresql)
 
 
 # Using PostgreSQL


### PR DESCRIPTION
I've updated the link for the badge to use vapor-community/postgresql instead of vapor/postgresql