### PR TITLE
Fixes memory leak.

### DIFF
--- a/Sources/PostgreSQL/Result.swift
+++ b/Sources/PostgreSQL/Result.swift
@@ -122,6 +122,7 @@ public class Result {
                             result: self,
                             bytes: value,
                             length: length,
+                            ownsMemory: false,
                             type: type,
                             format: .binary,
                             configuration: connection.configuration


### PR DESCRIPTION
This is one way how one could solve #66.

It breaks public interface, but I would argue that public interface had a design flaw in the first place because it was not clear who owns the passed buffer and who is responsible for cleaning up memory.

That was the actual cause for the bug in the first place.

I would suggest changing that interface to be more explicit, but if backwards compatibility is wanted, then there are other solutions.